### PR TITLE
fix(gatsby): makes dark-mode the only mode available

### DIFF
--- a/packages/gatsby/src/components/head/Head.tsx
+++ b/packages/gatsby/src/components/head/Head.tsx
@@ -12,6 +12,7 @@ export function Head({ title }: HeadProps) {
             <body
                 className={tw(
                     // background
+                    "dark",
                     "bg-zinc-50",
                     "dark:bg-zinc-950",
 

--- a/packages/gatsby/tailwind.config.js
+++ b/packages/gatsby/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+    darkMode: "selector",
     content: [
         `./src/pages/**/*.{js,jsx,ts,tsx}`,
         `./src/components/**/*.{js,jsx,ts,tsx}`,


### PR DESCRIPTION
This PR fix the dark-mode that was automatically switched with the user preferences, we fixed to dark-mode only.