### PR TITLE
fix(gatsby): change SEO component to Head element

### DIFF
--- a/packages/gatsby/src/components/head/Head.tsx
+++ b/packages/gatsby/src/components/head/Head.tsx
@@ -1,5 +1,6 @@
 import { tw } from "#root/lib";
 import React from "react";
+import { Seo } from "../seo";
 
 export type HeadProps = {
     title: string;
@@ -9,6 +10,7 @@ export function Head({ title }: HeadProps) {
     return (
         <>
             <title>{title}</title>
+            <Seo />
             <body
                 className={tw(
                     // background

--- a/packages/gatsby/src/templates/Template.tsx
+++ b/packages/gatsby/src/templates/Template.tsx
@@ -17,7 +17,6 @@ import {
     Layout,
     NetworkView,
     OptionsView,
-    Seo,
 } from "#root/components";
 
 export type ProviderProps = WrapPageElementBrowserArgs<
@@ -44,7 +43,6 @@ export function Template({ element, ...props }: ProviderProps) {
                                     {element}
                                 </Layout>
                             </NetworkSettingsProvider>
-                            <Seo />
                         </FilterProvider>
                     </CVProvider>
                 </I18nProvider>


### PR DESCRIPTION
This PR changes the SEO component position to the Head element